### PR TITLE
Fixing issue with too old bunyan-package because of old search-index

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "browserify": "11.0.1",
     "level-js": "2.2.1",
     "pouchdb": "^4.0.1",
-    "search-index": "0.6.8"
+    "search-index": "0.6.11"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
Same bunyan-issue with Firefox as the other search-index examples.
